### PR TITLE
Update firmware for gluon-v2014.4

### DIFF
--- a/_plugins/firmwares.rb
+++ b/_plugins/firmwares.rb
@@ -3,18 +3,26 @@ require 'uri'
 require 'nokogiri'
 require 'pp'
 
-FIRMWARE_REGEX = /^gluon-((\w+)-([\d\.]+)-([\w-]+)).bin$/
-HWREV_REGEX = /^(.+)-(v|rev-)(\w+)$/
+FIRMWARE_REGEX = /^gluon-((\w+)-([\d\.]+)-([\w-\.]+)).bin$/
+HWREV_REGEX = /^(.+)-(v|rev-)([\w\.]+)$/
 
 MODELMAP = {
-  "d-link-dir-615"         => { :make => "D-Link", :model => "DIR 615" },
-  "d-link-dir-825"         => { :make => "D-Link", :model => "DIR 825" },
+  "buffalo-wzr-hp-ag300h-wzr-600dhp"         => { :make => "Buffalo", :model => "WZR-HP-AG300H/600DHP" },
+  "buffalo-wzr-hp-g450h"                     => { :make => "Buffalo", :model => "WZR-HP-G450H" },
+
+  "d-link-dir-825"           => { :make => "D-Link", :model => "DIR 825" },
+
+  "linksys-wrt160nl"         => { :make => "Linksys", :model => "WRT160NL" },
 
   "ubiquiti-bullet-m"        => { :make => "Ubiquiti", :model => "Bullet M, Nanostation Loco M" },
   "ubiquiti-unifi"           => { :make => "Ubiquiti", :model => "UniFi AP (LR)" },
   "ubiquiti-nanostation-m"   => { :make => "Ubiquiti", :model => "Nanostation M" },
   "ubiquiti-unifiap-outdoor" => { :make => "Ubiquiti", :model => "UniFi AP Outdoor" },
 
+  "tp-link-cpe210"         => { :make => "TP-Link", :model => "CPE210" },
+  "tp-link-cpe220"         => { :make => "TP-Link", :model => "CPE220" },
+  "tp-link-cpe510"         => { :make => "TP-Link", :model => "CPE510" },
+  "tp-link-cpe520"         => { :make => "TP-Link", :model => "CPE520" },
   "tp-link-tl-mr3020"      => { :make => "TP-Link", :model => "TL-MR3020" },
   "tp-link-tl-mr3040"      => { :make => "TP-Link", :model => "TL-MR3040" },
   "tp-link-tl-mr3220"      => { :make => "TP-Link", :model => "TL-MR3220" },
@@ -22,7 +30,12 @@ MODELMAP = {
   "tp-link-tl-wdr3500"     => { :make => "TP-Link", :model => "TL-WDR3500" },
   "tp-link-tl-wdr3600"     => { :make => "TP-Link", :model => "TL-WDR3600" },
   "tp-link-tl-wdr4300"     => { :make => "TP-Link", :model => "TL-WDR4300" },
+  "tp-link-tl-wa750re"     => { :make => "TP-Link", :model => "TL-WA750RE" },
+  "tp-link-tl-wa801n-nd"   => { :make => "TP-Link", :model => "TL-WA801" },
+  "tp-link-tl-wa850re"     => { :make => "TP-Link", :model => "TL-WA850RE" },
   "tp-link-tl-wa901n-nd"   => { :make => "TP-Link", :model => "TL-WA901" },
+  "tp-link-tl-wr703n"      => { :make => "TP-Link", :model => "TL-WR703" },
+  "tp-link-tl-wr710n"      => { :make => "TP-Link", :model => "TL-WR710" },
   "tp-link-tl-wr740n-nd"   => { :make => "TP-Link", :model => "TL-WR740" },
   "tp-link-tl-wr741n-nd"   => { :make => "TP-Link", :model => "TL-WR741" },
   "tp-link-tl-wr841n-nd"   => { :make => "TP-Link", :model => "TL-WR841" },


### PR DESCRIPTION
Added new firmware models and removed one because of dropped support.