### PR TITLE
Added error handling for wrong firmware URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,8 +27,8 @@ community:
   geo_lat: 40.5
   geo_lon: -74.1
 
-firmware:
-  base: "http://gothamcity.freifunk.net/firmware/stable/"
+firmware: # something like http://gothamcity.freifunk.net/firmware/stable/
+  base: "http://add URL to your firmware here/"
   type: "gluon"
 
   # URL to the site repo (gitweb,github...)


### PR DESCRIPTION
If you run 

    jekyll build

without editing the `_config.yml` file and adding a valid URL for the firmware now you'll get the correct error messages and now the build will successfully continue, even if there is no such URL.