### PR TITLE
ffapi.json and caveat not to overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ possible, you may decided for something like
 	(cd _site && tar cf - .)|(cd /path/to/www && sudo tar xf -)
 
 to have the data transferred without deleting independent contributions.
+Caveat: Ensure not to overwrite files you may have edited manually, e.g.
+the _layouts/ffapi.json.
 
 Site
 ----


### PR DESCRIPTION
Added reminder to cross-check that nothing is overwritten that has previously been edited manually.

This happened on my end who I recalled to have put ffapi.json manually and I was unaware of it also being deployed via this startseite.