### PR TITLE
added Debian dependency for native ruby ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependencies
 
 On Ubuntu/Debian:
 
-    sudo apt-get install ruby-nokogiri
+    sudo apt-get install ruby-nokogiri ruby-dev
     sudo gem install json jekyll
 
 Customization


### PR DESCRIPTION
adding ruby-dev avoids running into this:

<pre>
root@www.ostholstein.freifunk.net:~/git/startseite#     sudo gem install json jekyll

Fetching: json-1.8.3.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing json:
	ERROR: Failed to build gem native extension.

    /usr/bin/ruby2.1 extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h
</pre>

Apparently that location is semi-magically provided via
<pre>
dpkg -S /usr/include/ruby-2.1.0/ruby.h
ruby2.1-dev:amd64: /usr/include/ruby-2.1.0/ruby.h
</pre>

Anyway ... works :)

Cheers,

Steffen